### PR TITLE
[fix] Allow creation of errors with code but no message

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function createError(msg, code, props) {
-    var err = typeof msg === 'string' ? new Error(msg) : msg;
+    var err =  msg instanceof Error ? msg : new Error(msg);
     var key;
 
     if (code != null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "err-code",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Create an error with a code",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -37,4 +37,12 @@ describe('errcode', function () {
         expect(err.foo).to.be('bar');
         expect(err.bar).to.be('foo');
     });
+
+    it('should create an error object with code and without message', function () {
+        var err = errcode(null, 'ESOME');
+
+        expect(err).to.be.an(Error);
+        expect(err.message).to.be('null');
+        expect(err.code).to.be('ESOME');
+    });
 });


### PR DESCRIPTION
Currently when creating an error with code but with a `null` message, the function fails. This fix enables that use case.
