### PR TITLE
Only support Error objects as the first argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ Create new error instances with a code and additional properties.
 
 ## Installation
 
-`$ npm install err-code` - `NPM`   
-`$ bower install err-code` - `bower`
+```console
+$ npm install err-code
+// or
+$ bower install err-code
+```
 
 The browser file is named index.umd.js which supports CommonJS, AMD and globals (errCode).
 
@@ -50,17 +53,6 @@ throw errcode(new Error('My message'), 'ESOMECODE');
 throw errcode(new Error('My message'), 'ESOMECODE', { detail: 'Additional information about the error' });
 // fill error with message + props
 throw errcode(new Error('My message'), { detail: 'Additional information about the error' });
-
-
-// You may also pass a string in the first argument and an error will be automatically created
-// for you, though the stack trace will contain err-code in it.
-
-// create error with message + code
-throw errcode('My message', 'ESOMECODE');
-// create error with message + code + props
-throw errcode('My message', 'ESOMECODE', { detail: 'Additional information about the error' });
-// create error with message + props
-throw errcode('My message', { detail: 'Additional information about the error' });
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 'use strict';
 
-function createError(msg, code, props) {
-    var err = msg instanceof Error ? msg : new Error(msg);
+function createError(err, code, props) {
     var key;
+
+    if (!(err instanceof Error)) {
+        throw new TypeError('Please pass an Error to err-code');
+    }
 
     if (typeof code === 'object') {
         props = code;

--- a/index.umd.js
+++ b/index.umd.js
@@ -1,9 +1,12 @@
-(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.errCode = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.errCode = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 'use strict';
 
-function createError(msg, code, props) {
-    var err = msg instanceof Error ? msg : new Error(msg);
+function createError(err, code, props) {
     var key;
+
+    if (!(err instanceof Error)) {
+        throw new TypeError('Please pass an Error to err-code');
+    }
 
     if (typeof code === 'object') {
         props = code;

--- a/test/test.js
+++ b/test/test.js
@@ -5,36 +5,10 @@ var expect = require('expect.js');
 
 describe('errcode', function () {
     describe('string as first argument', function () {
-        it('should create an error object without code', function () {
-            var err = errcode('my message');
-
-            expect(err).to.be.an(Error);
-            expect(err.hasOwnProperty(err.code)).to.be(false);
-        });
-
-        it('should create an error object with code', function () {
-            var err = errcode('my message', 'ESOME');
-
-            expect(err).to.be.an(Error);
-            expect(err.code).to.be('ESOME');
-        });
-
-        it('should create an error object with code and properties', function () {
-            var err = errcode('my message', 'ESOME', { foo: 'bar', bar: 'foo' });
-
-            expect(err).to.be.an(Error);
-            expect(err.code).to.be('ESOME');
-            expect(err.foo).to.be('bar');
-            expect(err.bar).to.be('foo');
-        });
-
-        it('should create an error object without code but with properties', function () {
-            var err = errcode('my message', { foo: 'bar', bar: 'foo' });
-
-            expect(err).to.be.an(Error);
-            expect(err.code).to.be(undefined);
-            expect(err.foo).to.be('bar');
-            expect(err.bar).to.be('foo');
+        it('should throw an error', function () {
+            expect(function () { errcode('my message'); }).to.throwError(function (err) {
+                expect(err).to.be.a(TypeError);
+            });
         });
     });
 
@@ -76,17 +50,17 @@ describe('errcode', function () {
         });
     });
 
-    it('should allow passing null & undefined in the first argument', function () {
-        var err;
+    describe('falsy first arguments', function () {
+        it('should not allow passing null as the first argument', function () {
+            expect(function () { errcode(null); }).to.throwError(function (err) {
+                expect(err).to.be.a(TypeError);
+            });
+        });
 
-        err = errcode(null, 'ESOME');
-        expect(err).to.be.an(Error);
-        expect(err.message).to.be('null');
-        expect(err.code).to.be('ESOME');
-
-        err = errcode(undefined, 'ESOME');
-        expect(err).to.be.an(Error);
-        expect(err.message).to.be('');
-        expect(err.code).to.be('ESOME');
+        it('should not allow passing undefined as the first argument', function () {
+            expect(function () { errcode(undefined); }).to.throwError(function (err) {
+                expect(err).to.be.a(TypeError);
+            });
+        });
     });
 });


### PR DESCRIPTION
If other types are passed in, a new `Error` object is created by this module which results in misleading stack traces.

Closes #19