### PR TITLE
fix: handle errors that throw on code assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ throw errcode(new Error('My message'), { detail: 'Additional information about t
 
 ## Pre-existing fields
 
-If the passed `Error` already has a `.code` field, or fields specified in the third argument to `errcode` they will be overwritten, unless the fields have been [defined as read-only](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) or the `Error` object has been [frozen](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze).
+If the passed `Error` already has a `.code` field, or fields specified in the third argument to `errcode` they will be overwritten, unless the fields are read only or otherwise throw during assignment in which case they will remain unchanged.
 
 
 ## Tests

--- a/index.js
+++ b/index.js
@@ -1,21 +1,5 @@
 'use strict';
 
-function maybeDefineProperty(obj, name, value) {
-    var descriptor;
-
-    if (Object.isFrozen(obj)) {
-        return;
-    }
-
-    descriptor = Object.getOwnPropertyDescriptor(obj, name);
-
-    if (descriptor && !descriptor.writable) {
-        return;
-    }
-
-    obj[name] = value;
-}
-
 function createError(err, code, props) {
     var key;
 
@@ -26,12 +10,16 @@ function createError(err, code, props) {
     if (typeof code === 'object') {
         props = code;
     } else if (code != null) {
-        maybeDefineProperty(err, 'code', code);
+        try {
+            err.code = code
+        } catch (err) { }
     }
 
     if (props) {
         for (key in props) {
-            maybeDefineProperty(err, key, props[key]);
+            try {
+                err[key] = props[key]
+            } catch (err) { }
         }
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,25 @@ describe('errcode', function () {
             expect(err).to.be.an(Error);
             expect(err.code).to.be(undefined);
         });
+
+        it('should not attempt to set on field that throws at assignment time', function () {
+            var myErr = new Error('my message');
+            var err;
+
+            Object.defineProperty(myErr, 'code', {
+                enumerable: true,
+                set: () => {
+                    throw new Error('Nope!')
+                },
+                get: () => {
+                    return 'derp'
+                }
+            });
+            err = errcode(myErr, 'ERR_WAT');
+
+            expect(err).to.be.an(Error);
+            expect(err.code).to.be('derp');
+        });
     });
 
     describe('falsy first arguments', function () {


### PR DESCRIPTION
`DOMException`s can have a non-enumerable `.code` property that throws if you try to assign it and does not have a property descriptor.  Take the nuclear option here and swallow thrown exceptions when we try to assign `.code` and any extra props.