### PR TITLE
fix: create a new error object when assigning code/props fails

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
     "root": true,
     "extends": [
-        "@satazor/eslint-config/es5",
+        "@satazor/eslint-config/es6",
         "@satazor/eslint-config/addons/node"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ throw errcode(new Error('My message'), { detail: 'Additional information about t
 
 ## Pre-existing fields
 
-If the passed `Error` already has a `.code` field, or fields specified in the third argument to `errcode` they will be overwritten, unless the fields are read only or otherwise throw during assignment in which case a new `Error` object will be created.  The `.stack` and `.message` properties will be carried over from the original error, and `.code` or any passed properties will be set on it.  The original error will be available via the `.cause` property of the returned error.
+If the passed `Error` already has a `.code` field, or fields specified in the third argument to `errcode` they will be overwritten, unless the fields are read only or otherwise throw during assignment in which case a new object will be created that shares a prototype chain with the original `Error`. The `.stack` and `.message` properties will be carried over from the original error and `.code` or any passed properties will be set on it.
 
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ throw errcode(new Error('My message'), { detail: 'Additional information about t
 
 ## Pre-existing fields
 
-If the passed `Error` already has a `.code` field, or fields specified in the third argument to `errcode` they will be overwritten, unless the fields are read only or otherwise throw during assignment in which case they will remain unchanged.
+If the passed `Error` already has a `.code` field, or fields specified in the third argument to `errcode` they will be overwritten, unless the fields are read only or otherwise throw during assignment in which case a new `Error` object will be created.  The `.stack` and `.message` properties will be carried over from the original error, and `.code` or any passed properties will be set on it.  The original error will be available via the `.cause` property of the returned error.
 
 
 ## Tests

--- a/index.js
+++ b/index.js
@@ -1,17 +1,10 @@
 'use strict';
 
 function assign(obj, props) {
-    let key;
-    let definition;
-
-    for (key in props) {
-        definition = Object.getOwnPropertyDescriptor(obj, key);
-
-        if (definition && !definition.writable) {
-            throw new TypeError(`Cannot assign to read only property '${key}' of object '${obj}'`);
-        }
-
-        obj[key] = props[key];
+    for (const key in props) {
+        Object.defineProperty(obj, key, {
+            value: props[key],
+        });
     }
 
     return obj;
@@ -45,15 +38,7 @@ function createError(err, code, props) {
 
         ErrClass.prototype = Object.create(Object.getPrototypeOf(err));
 
-        const newErr = new ErrClass();
-
-        for (const key in props) {
-            Object.defineProperty(newErr, key, {
-                value: props[key],
-            });
-        }
-
-        return newErr;
+        return assign(new ErrClass(), props);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function assign(obj, props) {
         Object.defineProperty(obj, key, {
             value: props[key],
             enumerable: true,
-            configurable: true
+            configurable: true,
         });
     }
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function createError(err, code, props) {
         code = undefined;
     }
 
-    if (code) {
+    if (code != null) {
         props.code = code;
     }
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ function assign(obj, props) {
     for (const key in props) {
         Object.defineProperty(obj, key, {
             value: props[key],
+            enumerable: true,
+            configurable: true
         });
     }
 

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 'use strict';
 
 function assign(obj, props) {
-    var key;
-    var definition;
+    let key;
+    let definition;
 
     for (key in props) {
         definition = Object.getOwnPropertyDescriptor(obj, key);
 
         if (definition && !definition.writable) {
-            throw new TypeError("Cannot assign to read only property '" + key + "' of object '" + obj + "'");
+            throw new TypeError(`Cannot assign to read only property '${key}' of object '${obj}'`);
         }
 
         obj[key] = props[key];
@@ -18,8 +18,6 @@ function assign(obj, props) {
 }
 
 function createError(err, code, props) {
-    var newErr;
-
     if (!(err instanceof Error)) {
         throw new TypeError('Please pass an Error to err-code');
     }
@@ -40,11 +38,22 @@ function createError(err, code, props) {
     try {
         return assign(err, props);
     } catch (_) {
-        props.cause = err;
-        newErr = new Error(err.message);
-        newErr.stack = err.stack;
+        props.message = err.message;
+        props.stack = err.stack;
 
-        return assign(newErr, props);
+        const ErrClass = function () {};
+
+        ErrClass.prototype = Object.create(Object.getPrototypeOf(err));
+
+        const newErr = new ErrClass();
+
+        for (const key in props) {
+            Object.defineProperty(newErr, key, {
+                value: props[key],
+            });
+        }
+
+        return newErr;
     }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,37 +1,37 @@
 'use strict';
 
-var errcode = require('../index');
-var expect = require('expect.js');
+const errcode = require('../index');
+const expect = require('expect.js');
 
-describe('errcode', function () {
-    describe('string as first argument', function () {
-        it('should throw an error', function () {
-            expect(function () { errcode('my message'); }).to.throwError(function (err) {
+describe('errcode', () => {
+    describe('string as first argument', () => {
+        it('should throw an error', () => {
+            expect(() => { errcode('my message'); }).to.throwError((err) => {
                 expect(err).to.be.a(TypeError);
             });
         });
     });
 
-    describe('error as first argument', function () {
-        it('should accept an error and do nothing', function () {
-            var myErr = new Error('my message');
-            var err = errcode(myErr);
+    describe('error as first argument', () => {
+        it('should accept an error and do nothing', () => {
+            const myErr = new Error('my message');
+            const err = errcode(myErr);
 
             expect(err).to.be(myErr);
             expect(err.hasOwnProperty(err.code)).to.be(false);
         });
 
-        it('should accept an error and add a code', function () {
-            var myErr = new Error('my message');
-            var err = errcode(myErr, 'ESOME');
+        it('should accept an error and add a code', () => {
+            const myErr = new Error('my message');
+            const err = errcode(myErr, 'ESOME');
 
             expect(err).to.be(myErr);
             expect(err.code).to.be('ESOME');
         });
 
-        it('should accept an error object and add code & properties', function () {
-            var myErr = new Error('my message');
-            var err = errcode(myErr, 'ESOME', { foo: 'bar', bar: 'foo' });
+        it('should accept an error object and add code & properties', () => {
+            const myErr = new Error('my message');
+            const err = errcode(myErr, 'ESOME', { foo: 'bar', bar: 'foo' });
 
             expect(err).to.be.an(Error);
             expect(err.code).to.be('ESOME');
@@ -39,9 +39,9 @@ describe('errcode', function () {
             expect(err.bar).to.be('foo');
         });
 
-        it('should create an error object without code but with properties', function () {
-            var myErr = new Error('my message');
-            var err = errcode(myErr, { foo: 'bar', bar: 'foo' });
+        it('should create an error object without code but with properties', () => {
+            const myErr = new Error('my message');
+            const err = errcode(myErr, { foo: 'bar', bar: 'foo' });
 
             expect(err).to.be.an(Error);
             expect(err.code).to.be(undefined);
@@ -49,63 +49,100 @@ describe('errcode', function () {
             expect(err.bar).to.be('foo');
         });
 
-        it('should set a non-writable field', function () {
-            var myErr = new Error('my message');
-            var err;
+        it('should set a non-writable field', () => {
+            const myErr = new Error('my message');
 
             Object.defineProperty(myErr, 'code', {
                 value: 'derp',
                 writable: false,
             });
-            err = errcode(myErr, 'ERR_WAT');
+            const err = errcode(myErr, 'ERR_WAT');
 
             expect(err).to.be.an(Error);
             expect(err.stack).to.equal(myErr.stack);
             expect(err.code).to.be('ERR_WAT');
-            expect(err.cause.code).to.be('derp');
         });
 
-        it('should add a code to frozen object', function () {
-            var myErr = new Error('my message');
-            var err = errcode(Object.freeze(myErr), 'ERR_WAT');
+        it('should add a code to frozen object', () => {
+            const myErr = new Error('my message');
+            const err = errcode(Object.freeze(myErr), 'ERR_WAT');
 
             expect(err).to.be.an(Error);
             expect(err.stack).to.equal(myErr.stack);
             expect(err.code).to.be('ERR_WAT');
-            expect(err.cause.code).to.be(undefined);
         });
 
-        it('should to set a field that throws at assignment time', function () {
-            var myErr = new Error('my message');
-            var err;
+        it('should to set a field that throws at assignment time', () => {
+            const myErr = new Error('my message');
 
             Object.defineProperty(myErr, 'code', {
                 enumerable: true,
-                set: function () {
+                set() {
                     throw new Error('Nope!');
                 },
-                get: function () {
+                get() {
                     return 'derp';
                 },
             });
-            err = errcode(myErr, 'ERR_WAT');
+            const err = errcode(myErr, 'ERR_WAT');
 
             expect(err).to.be.an(Error);
             expect(err.stack).to.equal(myErr.stack);
             expect(err.code).to.be('ERR_WAT');
-            expect(err.cause.code).to.be('derp');
+        });
+
+        it('should retain error type', () => {
+            const myErr = new TypeError('my message');
+
+            Object.defineProperty(myErr, 'code', {
+                value: 'derp',
+                writable: false,
+            });
+            const err = errcode(myErr, 'ERR_WAT');
+
+            expect(err).to.be.a(TypeError);
+            expect(err.stack).to.equal(myErr.stack);
+            expect(err.code).to.be('ERR_WAT');
+        });
+
+        it('should add a code to a class that extends Error', () => {
+            class CustomError extends Error {
+                set code(val) {
+                    throw new Error('Nope!');
+                }
+            }
+
+            const myErr = new CustomError('my message');
+
+            Object.defineProperty(myErr, 'code', {
+                value: 'derp',
+                writable: false,
+                configurable: false,
+            });
+            const err = errcode(myErr, 'ERR_WAT');
+
+            expect(err).to.be.a(CustomError);
+            expect(err.stack).to.equal(myErr.stack);
+            expect(err.code).to.be('ERR_WAT');
+
+            // original prototype chain should be intact
+            expect(() => {
+                const otherErr = new CustomError('my message');
+
+                otherErr.code = 'derp';
+            }).to.throwError();
         });
     });
 
-    describe('falsy first arguments', function () {
-        it('should not allow passing null as the first argument', function () {
-            expect(function () { errcode(null); }).to.throwError(function (err) {
+    describe('falsy first arguments', () => {
+        it('should not allow passing null as the first argument', () => {
+            expect(() => { errcode(null); }).to.throwError((err) => {
                 expect(err).to.be.a(TypeError);
             });
         });
 
-        it('should not allow passing undefined as the first argument', function () {
-            expect(function () { errcode(undefined); }).to.throwError(function (err) {
+        it('should not allow passing undefined as the first argument', () => {
+            expect(() => { errcode(undefined); }).to.throwError((err) => {
                 expect(err).to.be.a(TypeError);
             });
         });

--- a/test/test.js
+++ b/test/test.js
@@ -49,7 +49,7 @@ describe('errcode', function () {
             expect(err.bar).to.be('foo');
         });
 
-        it('should not attempt to set non-writable field', function () {
+        it('should set a non-writable field', function () {
             var myErr = new Error('my message');
             var err;
 
@@ -60,34 +60,40 @@ describe('errcode', function () {
             err = errcode(myErr, 'ERR_WAT');
 
             expect(err).to.be.an(Error);
-            expect(err.code).to.be('derp');
+            expect(err.stack).to.equal(myErr.stack);
+            expect(err.code).to.be('ERR_WAT');
+            expect(err.cause.code).to.be('derp');
         });
 
-        it('should not add code to frozen object', function () {
+        it('should add a code to frozen object', function () {
             var myErr = new Error('my message');
             var err = errcode(Object.freeze(myErr), 'ERR_WAT');
 
             expect(err).to.be.an(Error);
-            expect(err.code).to.be(undefined);
+            expect(err.stack).to.equal(myErr.stack);
+            expect(err.code).to.be('ERR_WAT');
+            expect(err.cause.code).to.be(undefined);
         });
 
-        it('should not attempt to set on field that throws at assignment time', function () {
+        it('should to set a field that throws at assignment time', function () {
             var myErr = new Error('my message');
             var err;
 
             Object.defineProperty(myErr, 'code', {
                 enumerable: true,
-                set: () => {
-                    throw new Error('Nope!')
+                set: function () {
+                    throw new Error('Nope!');
                 },
-                get: () => {
-                    return 'derp'
-                }
+                get: function () {
+                    return 'derp';
+                },
             });
             err = errcode(myErr, 'ERR_WAT');
 
             expect(err).to.be.an(Error);
-            expect(err.code).to.be('derp');
+            expect(err.stack).to.equal(myErr.stack);
+            expect(err.code).to.be('ERR_WAT');
+            expect(err.cause.code).to.be('derp');
         });
     });
 


### PR DESCRIPTION
This module is supposed to add a `.code` property to an `Error` object - if this fails, it can create hard to track down bugs as the calling code expects there to be a `.code` property on the error.

Here we create a new `Error` if assigning the passed `.code` or props fails. The original error message and stack trace are used on the new error, and the original error instance is accessible via the `.cause` property on the returned error.