### PR TITLE
fix: remove instanceof check for passed error

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function assign(obj, props) {
 }
 
 function createError(err, code, props) {
-    if (!(err instanceof Error)) {
+    if (!err || typeof err === 'string') {
         throw new TypeError('Please pass an Error to err-code');
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -132,6 +132,15 @@ describe('errcode', () => {
                 otherErr.code = 'derp';
             }).to.throwError();
         });
+
+        it('should support errors that are not Errors', () => {
+            const err = errcode({
+                message: 'Oh noes!',
+            }, 'ERR_WAT');
+
+            expect(err.message).to.be('Oh noes!');
+            expect(err.code).to.be('ERR_WAT');
+        });
     });
 
     describe('falsy first arguments', () => {


### PR DESCRIPTION
When an Error is created in a different context (e.g. in a browser iframe or similar), `instanceof` doesn't work.

The change here is to remove the `instanceof` check and instead just ensure that the `err` argument is truthy and is not a string to catch the older style of passing an error message in as the first argument.